### PR TITLE
Enhance GPA calculator with academic year filtering

### DIFF
--- a/grade-calculator/gpa-calculator.html
+++ b/grade-calculator/gpa-calculator.html
@@ -24,6 +24,13 @@
                 <button type="button" id="expand-all" class="expand-btn">Expand All</button>
                 <button type="button" id="collapse-all" class="collapse-btn">Collapse All</button>
             </div>
+            <select id="year-filter" class="year-dropdown">
+                <option value="all">All Years</option>
+                <option value="freshman">Freshman</option>
+                <option value="sophomore">Sophomore</option>
+                <option value="junior">Junior</option>
+                <option value="senior">Senior</option>
+            </select>
         </div>
         
         <table class="gpa-table pivot-table">

--- a/grade-calculator/gpa-calculator.js
+++ b/grade-calculator/gpa-calculator.js
@@ -32,6 +32,31 @@ let expandedSemesters = {};
 // Store current filter for selecting a semester ('all' shows all)
 let currentFilter = 'all';
 
+// Filter by academic year
+let currentYearFilter = 'all';
+const semesterYearMap = {
+    'freshman_fall': 'freshman',
+    'freshman_spring': 'freshman',
+    'sophomore_fall': 'sophomore',
+    'sophomore_spring': 'sophomore',
+    'junior_fall': 'junior',
+    'junior_spring': 'junior',
+    'senior_fall': 'senior',
+    'senior_spring': 'senior'
+};
+
+// Display semesters in a fixed academic order
+const orderedSemesters = [
+    'freshman_fall',
+    'freshman_spring',
+    'sophomore_fall',
+    'sophomore_spring',
+    'junior_fall',
+    'junior_spring',
+    'senior_fall',
+    'senior_spring'
+];
+
 // Determine letter grade from GPA
 function getLetterGradeFromGpa(gpa) {
     if (gpa >= 4.0) return 'A+';
@@ -315,8 +340,15 @@ function updateGpaTable() {
     const selectedSemesterId = currentFilter;
     const semesterHeading = document.getElementById('gpa-semester-heading');
 
-    // Update heading based on filter
-    semesterHeading.textContent = selectedSemesterId === 'all' ? 'All Semesters' : semesters[selectedSemesterId]?.name || 'Semester';
+    let headingText = '';
+    if (selectedSemesterId !== 'all') {
+        headingText = semesters[selectedSemesterId]?.name || 'Semester';
+    } else if (currentYearFilter !== 'all') {
+        headingText = `${currentYearFilter.charAt(0).toUpperCase()}${currentYearFilter.slice(1)} Year`;
+    } else {
+        headingText = 'All Semesters';
+    }
+    semesterHeading.textContent = headingText;
 
     // Clear existing rows
     gpaTableBody.innerHTML = '';
@@ -444,9 +476,14 @@ function updateGpaTable() {
     
     // Add semesters based on selected semester
     if (selectedSemesterId === 'all') {
-        // Add all semesters
-        Object.keys(semesters).forEach(semesterId => {
-            addSemesterWithClasses(semesterId);
+        // Add semesters in predefined order if they exist and match year filter
+        orderedSemesters.forEach(semId => {
+            if (
+                semesters[semId] &&
+                (currentYearFilter === 'all' || semesterYearMap[semId] === currentYearFilter)
+            ) {
+                addSemesterWithClasses(semId);
+            }
         });
     } else if (semesters[selectedSemesterId]) {
         // Add just the selected semester
@@ -579,6 +616,17 @@ document.addEventListener('DOMContentLoaded', () => {
         });
         updateGpaTable();
     });
+
+    // Change year filter
+    const yearSelect = document.getElementById('year-filter');
+    if (yearSelect) {
+        yearSelect.addEventListener('change', () => {
+            currentYearFilter = yearSelect.value;
+            // Collapse semesters when changing filter
+            Object.keys(expandedSemesters).forEach(id => expandedSemesters[id] = false);
+            updateGpaTable();
+        });
+    }
     
     // Add event listeners for prior GPA and credits
     document.getElementById('prior-gpa').addEventListener('input', () => {

--- a/grade-calculator/gpa-styles.css
+++ b/grade-calculator/gpa-styles.css
@@ -84,6 +84,15 @@
     min-width: 200px;
 }
 
+.year-dropdown {
+    padding: 8px 12px;
+    border-radius: 8px;
+    border: 1px solid rgba(90, 90, 90, 0.3);
+    background-color: rgba(42, 42, 42, 0.7);
+    color: #e0e0e0;
+    min-width: 150px;
+}
+
 /* Pivot table styles */
 .pivot-table {
     border-collapse: separate;

--- a/grade-calculator/script.js
+++ b/grade-calculator/script.js
@@ -2,9 +2,73 @@
 console.log('Grade Calculator script loaded');
 
 // Store semester data with classes inside
+// Predefined semesters for four academic years
 let semesters = {
-    'semester1': {
-        name: 'Semester 1',
+    'freshman_fall': {
+        name: 'Freshman Fall',
+        classes: {
+            'class1': {
+                name: 'Class 1',
+                assignments: []
+            }
+        }
+    },
+    'freshman_spring': {
+        name: 'Freshman Spring',
+        classes: {
+            'class1': {
+                name: 'Class 1',
+                assignments: []
+            }
+        }
+    },
+    'sophomore_fall': {
+        name: 'Sophomore Fall',
+        classes: {
+            'class1': {
+                name: 'Class 1',
+                assignments: []
+            }
+        }
+    },
+    'sophomore_spring': {
+        name: 'Sophomore Spring',
+        classes: {
+            'class1': {
+                name: 'Class 1',
+                assignments: []
+            }
+        }
+    },
+    'junior_fall': {
+        name: 'Junior Fall',
+        classes: {
+            'class1': {
+                name: 'Class 1',
+                assignments: []
+            }
+        }
+    },
+    'junior_spring': {
+        name: 'Junior Spring',
+        classes: {
+            'class1': {
+                name: 'Class 1',
+                assignments: []
+            }
+        }
+    },
+    'senior_fall': {
+        name: 'Senior Fall',
+        classes: {
+            'class1': {
+                name: 'Class 1',
+                assignments: []
+            }
+        }
+    },
+    'senior_spring': {
+        name: 'Senior Spring',
         classes: {
             'class1': {
                 name: 'Class 1',
@@ -14,7 +78,7 @@ let semesters = {
     }
 };
 
-let currentSemesterId = 'semester1';
+let currentSemesterId = 'freshman_fall';
 let currentClassId = 'class1';
 
 // Load data from localStorage if available


### PR DESCRIPTION
## Summary
- preset 8 semesters for four academic years
- order GPA table by academic year and allow year filtering
- add year drop-down on GPA calculator page
- style new drop-down

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686330bbb1ec832c967d31264462300a